### PR TITLE
change: autocomplete attr value to "new-password"

### DIFF
--- a/src/SinChar.ts
+++ b/src/SinChar.ts
@@ -58,7 +58,7 @@ export class SinChar {
       digit.setAttribute('maxlength', '1');
       digit.setAttribute('autocapitalize', 'off');
       digit.setAttribute('autocorrect', 'off');
-      digit.setAttribute('autocomplete', 'off');
+      digit.setAttribute('autocomplete', 'new-password');
 
       if (this.numbersOnly) {
           digit.setAttribute('inputmode', 'numeric');


### PR DESCRIPTION
**autocomplete="off"** doesn't work in Сhrome and fills the last input field with the first character from remembered login